### PR TITLE
don't swallow partial match at the end of the sentence

### DIFF
--- a/src/Shdev/FlashText/KeywordProcessor.php
+++ b/src/Shdev/FlashText/KeywordProcessor.php
@@ -561,6 +561,8 @@ class KeywordProcessor
                 if (isset($currentDict[self::TREE_LEAF])) {
                     $sequenceFound = $currentDict[self::TREE_LEAF];
                     $newSentence .= $sequenceFound;
+                } elseif ($currentWord) {
+                    $newSentence .= $currentWord;
                 }
             }
             ++$idx;

--- a/tests/Shdev/FlashText/KeywordProcessor/keyword_extractor_test_cases.json
+++ b/tests/Shdev/FlashText/KeywordProcessor/keyword_extractor_test_cases.json
@@ -467,5 +467,14 @@
         "explanation": "",
         "keywords": ["spring framework"],
         "keywords_case_sensitive": ["spring framework"]
+    },
+    {
+        "sentence": "what the heck is java",
+        "keyword_dict": {
+            "java": ["javanese"]
+        },
+        "explanation": "prefix match at the end of the sentence",
+        "keywords": [],
+        "keywords_case_sensitive": []
     }
 ]


### PR DESCRIPTION
Hi @shdev, I run into a problem with the implementation when the last part of a sentence was a prefix of a given keyword (replace mode). Then the matching part of the sentence is just dropped from the new sentence. This PR fixes the problem.

Let me know if you have questions and thanks for porting to flashtext algo to PHP. 

Best,
Pascal